### PR TITLE
refactor choices in Model_Asset

### DIFF
--- a/src/assetdialog.cpp
+++ b/src/assetdialog.cpp
@@ -122,9 +122,9 @@ void mmAssetDialog::dataToControls()
 
     m_valueChangeRate->SetValue(m_asset->VALUECHANGERATE, 3);
 
-    m_valueChange->SetSelection(Model_Asset::rate(m_asset));
-    enableDisableRate(Model_Asset::rate(m_asset) != Model_Asset::RATE_NONE);
-    m_assetType->SetSelection(Model_Asset::type(m_asset));
+    m_valueChange->SetSelection(Model_Asset::change_id(m_asset));
+    enableDisableRate(Model_Asset::change_id(m_asset) != Model_Asset::CHANGE_ID_NONE);
+    m_assetType->SetSelection(Model_Asset::type_id(m_asset));
 
     // Set up the transaction if this is the first entry.
     if (translink.empty())
@@ -190,11 +190,11 @@ void mmAssetDialog::CreateControls()
     itemFlexGridSizer6->Add(new wxStaticText(asset_details_panel, wxID_STATIC, _("Asset Type")), g_flagsH);
 
     m_assetType = new wxChoice(asset_details_panel, wxID_STATIC);
-    for (const auto& a : Model_Asset::all_type())
+    for (const auto& a : Model_Asset::TYPE_STR)
         m_assetType->Append(wxGetTranslation(a), new wxStringClientData(a));
 
     mmToolTip(m_assetType, _("Select type of asset"));
-    m_assetType->SetSelection(Model_Asset::TYPE_PROPERTY);
+    m_assetType->SetSelection(Model_Asset::TYPE_ID_PROPERTY);
     itemFlexGridSizer6->Add(m_assetType, g_flagsExpand);
 
     wxStaticText* v = new wxStaticText(asset_details_panel, wxID_STATIC, _("Value"));
@@ -210,11 +210,11 @@ void mmAssetDialog::CreateControls()
     itemFlexGridSizer6->Add(new wxStaticText(asset_details_panel, wxID_STATIC, _("Change in Value")), g_flagsH);
 
     m_valueChange = new wxChoice(asset_details_panel, IDC_COMBO_TYPE);
-    for(const auto& a : Model_Asset::all_rate())
+    for(const auto& a : Model_Asset::CHANGE_STR)
         m_valueChange->Append(wxGetTranslation(a));
 
     mmToolTip(m_valueChange, _("Specify if the value of the asset changes over time"));
-    m_valueChange->SetSelection(Model_Asset::RATE_NONE);
+    m_valueChange->SetSelection(Model_Asset::CHANGE_ID_NONE);
     itemFlexGridSizer6->Add(m_valueChange, g_flagsExpand);
 
     m_valueChangeRateLabel = new wxStaticText(asset_details_panel, wxID_STATIC, _("% Rate"));
@@ -301,7 +301,7 @@ void mmAssetDialog::OnChangeAppreciationType(wxCommandEvent& /*event*/)
 {
     int selection = m_valueChange->GetSelection();
     // Disable for "None", Enable for "Appreciates" or "Depreciates"
-    enableDisableRate(selection != Model_Asset::RATE_NONE);
+    enableDisableRate(selection != Model_Asset::CHANGE_ID_NONE);
 }
 
 void mmAssetDialog::enableDisableRate(bool en)
@@ -337,7 +337,7 @@ void mmAssetDialog::OnOk(wxCommandEvent& /*event*/)
     }
 
     int valueChangeType = m_valueChange->GetSelection();
-    if (valueChangeType != Model_Asset::RATE_NONE && !m_valueChangeRate->checkValue(valueChangeRate))
+    if (valueChangeType != Model_Asset::CHANGE_ID_NONE && !m_valueChangeRate->checkValue(valueChangeRate))
     {
         return;
     }
@@ -352,11 +352,11 @@ void mmAssetDialog::OnOk(wxCommandEvent& /*event*/)
     m_asset->STARTDATE        = m_dpc->GetValue().FormatISODate();
     m_asset->NOTES            = m_notes->GetValue().Trim();
     m_asset->ASSETNAME        = name;
-    m_asset->ASSETSTATUS      = Model_Asset::OPEN_STR;
-    m_asset->VALUECHANGEMODE  = Model_Asset::PERCENTAGE_STR;  
+    m_asset->ASSETSTATUS      = Model_Asset::STATUS_STR[Model_Asset::STATUS_ID_OPEN];
+    m_asset->VALUECHANGEMODE  = Model_Asset::CHANGEMODE_STR[Model_Asset::CHANGEMODE_ID_PERCENTAGE];  
     m_asset->CURRENCYID       = -1; 
     m_asset->VALUE            = value;
-    m_asset->VALUECHANGE      = Model_Asset::all_rate()[valueChangeType];
+    m_asset->VALUECHANGE      = Model_Asset::CHANGE_STR[valueChangeType];
     m_asset->VALUECHANGERATE  = valueChangeRate;
     m_asset->ASSETTYPE        = asset_type;
 

--- a/src/assetspanel.cpp
+++ b/src/assetspanel.cpp
@@ -149,7 +149,7 @@ void mmAssetsListCtrl::OnListItemSelected(wxListEvent& event)
 
 int mmAssetsListCtrl::OnGetItemImage(long item) const
 {
-    return Model_Asset::type(m_panel->m_assets[item]);
+    return Model_Asset::type_id(m_panel->m_assets[item]);
 }
 
 void mmAssetsListCtrl::OnListKeyDown(wxListEvent& event)
@@ -366,7 +366,7 @@ END_EVENT_TABLE()
 
 mmAssetsPanel::mmAssetsPanel(mmGUIFrame* frame, wxWindow *parent, wxWindowID winid, const wxString& name)
     : m_frame(frame)
-    , m_filter_type(Model_Asset::TYPE(-1))
+    , m_filter_type(Model_Asset::TYPE_ID(-1))
     , tips_()
 {
     Create(parent, winid, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, name);
@@ -570,7 +570,7 @@ int mmAssetsPanel::initVirtualListControl(int id, int col, bool asc)
     item.SetImage(asc ? ICON_UPARROW : ICON_DOWNARROW);
     m_listCtrlAssets->SetColumn(col, item);
 
-    if (this->m_filter_type == Model_Asset::TYPE(-1)) // ALL
+    if (this->m_filter_type == Model_Asset::TYPE_ID(-1)) // ALL
         this->m_assets = Model_Asset::instance().all();
     else
         this->m_assets = Model_Asset::instance().find(Model_Asset::ASSETTYPE(m_filter_type));
@@ -661,7 +661,7 @@ void mmAssetsPanel::updateExtraAssetData(int selIndex)
     {
         const Model_Asset::Data& asset = this->m_assets[selIndex];
         enableEditDeleteButtons(true);
-        const auto& change_rate = (Model_Asset::rate(asset) != Model_Asset::RATE_NONE)
+        const auto& change_rate = (Model_Asset::change_id(asset) != Model_Asset::CHANGE_ID_NONE)
             ? wxString::Format("%.2f %%", asset.VALUECHANGERATE) : "";
         const wxString& miniInfo = " " + wxString::Format(_("Change in Value: %1$s %2$s")
             , wxGetTranslation(asset.VALUECHANGE), change_rate);
@@ -704,7 +704,7 @@ void mmAssetsPanel::OnMouseLeftDown (wxCommandEvent& event)
     wxMenu menu;
     menu.Append(++i, wxGetTranslation(wxTRANSLATE("All")));
 
-    for (const auto& type: Model_Asset::all_type())
+    for (const auto& type: Model_Asset::TYPE_STR)
     {
         menu.Append(++i, wxGetTranslation(type));
     }
@@ -721,13 +721,13 @@ void mmAssetsPanel::OnViewPopupSelected(wxCommandEvent& event)
     {
         m_bitmapTransFilter->SetLabel(_("All"));
         m_bitmapTransFilter->SetBitmap(mmBitmapBundle(png::TRANSFILTER, mmBitmapButtonSize));
-        this->m_filter_type = Model_Asset::TYPE(-1);
+        this->m_filter_type = Model_Asset::TYPE_ID(-1);
     }
     else
     {
-        this->m_filter_type = Model_Asset::TYPE(evt - 1);
+        this->m_filter_type = Model_Asset::TYPE_ID(evt - 1);
         m_bitmapTransFilter->SetBitmap(mmBitmapBundle(png::TRANSFILTER_ACTIVE, mmBitmapButtonSize));
-        m_bitmapTransFilter->SetLabel(wxGetTranslation(Model_Asset::all_type()[evt - 1]));
+        m_bitmapTransFilter->SetLabel(wxGetTranslation(Model_Asset::TYPE_STR[evt - 1]));
     }
 
     int trx_id = -1;

--- a/src/assetspanel.h
+++ b/src/assetspanel.h
@@ -101,7 +101,7 @@ public:
     wxString getItem(long item, long column);
 
     Model_Asset::Data_Set m_assets;
-    Model_Asset::TYPE m_filter_type;
+    Model_Asset::TYPE_ID m_filter_type;
     int col_max() { return COL_MAX; }
     int col_sort() { return COL_DATE; }
 

--- a/src/model/Model.h
+++ b/src/model/Model.h
@@ -122,7 +122,7 @@ public:
     Args: One or more Specialised Parameters creating SQL statement conditions used after the WHERE statement.
     Specialised Parameters: Table_Column_Name(content)[, Table_Column_Name(content)[, ...]]
     Example:
-    Model_Asset::ASSETID(2), Model_Asset::ASSETTYPE(Model_Asset::TYPE_JEWELLERY)
+    Model_Asset::ASSETID(2), Model_Asset::ASSETTYPE(Model_Asset::TYPE_ID_JEWELLERY)
     produces SQL statement condition: ASSETID = 2 AND ASSETTYPE = "Jewellery"
     * Returns a Data_Set containing the addresses of the items found.
     * The Data_Set is empty when nothing found.
@@ -138,7 +138,7 @@ public:
     Args: One or more Specialised Parameters creating SQL statement conditions used after the WHERE statement.
     Specialised Parameters: Table_Column_Name(content)[, Table_Column_Name(content)[, ...]]
     Example:
-    Model_Asset::ASSETID(2), Model_Asset::ASSETTYPE(Model_Asset::TYPE_JEWELLERY)
+    Model_Asset::ASSETID(2), Model_Asset::ASSETTYPE(Model_Asset::TYPE_ID_JEWELLERY)
     produces SQL statement condition: ASSETID = 2 OR ASSETTYPE = "Jewellery"
     * Returns a Data_Set containing the addresses of the items found.
     * The Data_Set is empty when nothing found.

--- a/src/model/Model_Asset.cpp
+++ b/src/model/Model_Asset.cpp
@@ -21,41 +21,40 @@
 #include "Model_Translink.h"
 #include "Model_CurrencyHistory.h"
 
-const std::vector<std::pair<Model_Asset::RATE, wxString> > Model_Asset::RATE_CHOICES = 
+const std::vector<std::pair<Model_Asset::TYPE_ID, wxString> > Model_Asset::TYPE_CHOICES = 
 {
-    {Model_Asset::RATE_NONE, wxString(wxTRANSLATE("None"))}
-    , {Model_Asset::RATE_APPRECIATE, wxString(wxTRANSLATE("Appreciates"))}
-    , {Model_Asset::RATE_DEPRECIATE, wxString(wxTRANSLATE("Depreciates"))}
+    { Model_Asset::TYPE_ID_PROPERTY,  wxString(wxTRANSLATE("Property")) },
+    { Model_Asset::TYPE_ID_AUTO,      wxString(wxTRANSLATE("Automobile")) },
+    { Model_Asset::TYPE_ID_HOUSE,     wxString(wxTRANSLATE("Household Object")) },
+    { Model_Asset::TYPE_ID_ART,       wxString(wxTRANSLATE("Art")) },
+    { Model_Asset::TYPE_ID_JEWELLERY, wxString(wxTRANSLATE("Jewellery")) },
+    { Model_Asset::TYPE_ID_CASH,      wxString(wxTRANSLATE("Cash")) },
+    { Model_Asset::TYPE_ID_OTHER,     wxString(wxTRANSLATE("Other")) }
 };
 
-const std::vector<std::pair<Model_Asset::RATEMODE, wxString> > Model_Asset::RATEMODE_CHOICES = 
+const std::vector<std::pair<Model_Asset::STATUS_ID, wxString> > Model_Asset::STATUS_CHOICES = 
 {
-    {Model_Asset::PERCENTAGE, wxString(wxTRANSLATE("Percentage"))}
-    , {Model_Asset::LINEAR, wxString(wxTRANSLATE("Linear"))}
+    { Model_Asset::STATUS_ID_CLOSED, wxString(wxTRANSLATE("Closed")) },
+    { Model_Asset::STATUS_ID_OPEN,   wxString(wxTRANSLATE("Open")) }
 };
 
-const wxString Model_Asset::PERCENTAGE_STR = all_ratemode()[PERCENTAGE];
-const wxString Model_Asset::LINEAR_STR = all_ratemode()[LINEAR];
-
-const std::vector<std::pair<Model_Asset::TYPE, wxString> > Model_Asset::TYPE_CHOICES = 
+const std::vector<std::pair<Model_Asset::CHANGE_ID, wxString> > Model_Asset::CHANGE_CHOICES = 
 {
-    {Model_Asset::TYPE_PROPERTY, wxString(wxTRANSLATE("Property"))}
-    , {Model_Asset::TYPE_AUTO, wxString(wxTRANSLATE("Automobile"))}
-    , {Model_Asset::TYPE_HOUSE, wxString(wxTRANSLATE("Household Object"))}
-    , {Model_Asset::TYPE_ART, wxString(wxTRANSLATE("Art"))}
-    , {Model_Asset::TYPE_JEWELLERY, wxString(wxTRANSLATE("Jewellery"))}
-    , {Model_Asset::TYPE_CASH, wxString(wxTRANSLATE("Cash"))}
-    , {Model_Asset::TYPE_OTHER, wxString(wxTRANSLATE("Other"))}
+    { Model_Asset::CHANGE_ID_NONE,       wxString(wxTRANSLATE("None")) },
+    { Model_Asset::CHANGE_ID_APPRECIATE, wxString(wxTRANSLATE("Appreciates")) },
+    { Model_Asset::CHANGE_ID_DEPRECIATE, wxString(wxTRANSLATE("Depreciates")) }
 };
 
-const std::vector<std::pair<Model_Asset::STATUS, wxString> > Model_Asset::STATUS_CHOICES = 
+const std::vector<std::pair<Model_Asset::CHANGEMODE_ID, wxString> > Model_Asset::CHANGEMODE_CHOICES = 
 {
-    {Model_Asset::STATUS_CLOSED, wxString(wxTRANSLATE("Closed"))}
-    , {Model_Asset::STATUS_OPEN, wxString(wxTRANSLATE("Open"))}
+    { Model_Asset::CHANGEMODE_ID_PERCENTAGE, wxString(wxTRANSLATE("Percentage")) },
+    { Model_Asset::CHANGEMODE_ID_LINEAR,     wxString(wxTRANSLATE("Linear")) }
 };
 
-const wxString Model_Asset::OPEN_STR = all_status()[STATUS_OPEN];
-const wxString Model_Asset::CLOSED_STR = all_status()[STATUS_CLOSED];
+wxArrayString Model_Asset::TYPE_STR = type_str_all();
+wxArrayString Model_Asset::STATUS_STR = status_str_all();
+wxArrayString Model_Asset::CHANGE_STR = change_str_all();
+wxArrayString Model_Asset::CHANGEMODE_STR = changemode_str_all();
 
 Model_Asset::Model_Asset()
 : Model<DB_Table_ASSETS_V1>()
@@ -95,32 +94,52 @@ wxString Model_Asset::get_asset_name(int asset_id)
         return _("Asset Error");
 }
 
-wxArrayString Model_Asset::all_rate()
-{
-    wxArrayString rates;
-    for (const auto& item: RATE_CHOICES) rates.Add(item.second);
-    return rates;
-}
-
-wxArrayString Model_Asset::all_ratemode()
-{
-    wxArrayString ratemodes;
-    for (const auto& item: RATEMODE_CHOICES) ratemodes.Add(item.second);
-    return ratemodes;
-}
-
-wxArrayString Model_Asset::all_type()
+wxArrayString Model_Asset::type_str_all()
 {
     wxArrayString types;
-    for (const auto& item: TYPE_CHOICES) types.Add(item.second);
+    int i = 0;
+    for (const auto& item: TYPE_CHOICES)
+    {
+        wxASSERT_MSG(item.first == i++, "Wrong order in Model_Asset::TYPE_CHOICES");
+        types.Add(item.second);
+    }
     return types;
 }
 
-wxArrayString Model_Asset::all_status()
+wxArrayString Model_Asset::status_str_all()
 {
     wxArrayString statusList;
-    for (const auto& item: STATUS_CHOICES) statusList.Add(item.second);
+    int i = 0;
+    for (const auto& item: STATUS_CHOICES)
+    {
+        wxASSERT_MSG(item.first == i++, "Wrong order in Model_Asset::STATUS_CHOICES");
+        statusList.Add(item.second);
+    }
     return statusList;
+}
+
+wxArrayString Model_Asset::change_str_all()
+{
+    wxArrayString rates;
+    int i = 0;
+    for (const auto& item: CHANGE_CHOICES)
+    {
+        wxASSERT_MSG(item.first == i++, "Wrong order in Model_Asset::CHANGE_CHOICES");
+        rates.Add(item.second);
+    }
+    return rates;
+}
+
+wxArrayString Model_Asset::changemode_str_all()
+{
+    wxArrayString changemodes;
+    int i = 0;
+    for (const auto& item: CHANGEMODE_CHOICES)
+    {
+        wxASSERT_MSG(item.first == i++, "Wrong order in Model_Asset::CHANGEMODE_CHOICES");
+        changemodes.Add(item.second);
+    }
+    return changemodes;
 }
 
 double Model_Asset::balance()
@@ -133,9 +152,9 @@ double Model_Asset::balance()
     return balance;
 }
 
-DB_Table_ASSETS_V1::ASSETTYPE Model_Asset::ASSETTYPE(TYPE type, OP op)
+DB_Table_ASSETS_V1::ASSETTYPE Model_Asset::ASSETTYPE(TYPE_ID type, OP op)
 {
-    return DB_Table_ASSETS_V1::ASSETTYPE(all_type()[type], op);
+    return DB_Table_ASSETS_V1::ASSETTYPE(TYPE_STR[type], op);
 }
 
 DB_Table_ASSETS_V1::STARTDATE Model_Asset::STARTDATE(const wxDate& date, OP op)
@@ -153,49 +172,48 @@ wxDate Model_Asset::STARTDATE(const Data& r)
     return Model::to_date(r.STARTDATE);
 }
 
-Model_Asset::TYPE Model_Asset::type(const Data* r)
+Model_Asset::TYPE_ID Model_Asset::type_id(const Data* r)
 {
-    for (const auto& item : TYPE_CHOICES) if (item.second.CmpNoCase(r->ASSETTYPE) == 0) return item.first;
-
-    return TYPE(-1);
+    for (const auto& item : TYPE_CHOICES)
+        if (item.second.CmpNoCase(r->ASSETTYPE) == 0) return item.first;
+    return TYPE_ID(-1);
+}
+Model_Asset::TYPE_ID Model_Asset::type_id(const Data& r)
+{
+    return type_id(&r);
 }
 
-Model_Asset::TYPE Model_Asset::type(const Data& r)
+Model_Asset::STATUS_ID Model_Asset::status_id(const Data* r)
 {
-    return type(&r);
+    for (const auto & item : STATUS_CHOICES)
+        if (item.second.CmpNoCase(r->ASSETSTATUS) == 0) return item.first;
+    return STATUS_ID(-1);
+}
+Model_Asset::STATUS_ID Model_Asset::status_id(const Data& r)
+{
+    return status_id(&r);
 }
 
-Model_Asset::RATE Model_Asset::rate(const Data* r)
+Model_Asset::CHANGE_ID Model_Asset::change_id(const Data* r)
 {
-    for (const auto & item : RATE_CHOICES) if (item.second.CmpNoCase(r->VALUECHANGE) == 0) return item.first;
-    return RATE(-1);
+    for (const auto & item : CHANGE_CHOICES)
+        if (item.second.CmpNoCase(r->VALUECHANGE) == 0) return item.first;
+    return CHANGE_ID(-1);
+}
+Model_Asset::CHANGE_ID Model_Asset::change_id(const Data& r)
+{
+    return change_id(&r);
 }
 
-Model_Asset::RATE Model_Asset::rate(const Data& r)
+Model_Asset::CHANGEMODE_ID Model_Asset::changemode_id(const Data* r)
 {
-    return rate(&r);
+    for (const auto & item : CHANGEMODE_CHOICES)
+        if (item.second.CmpNoCase(r->VALUECHANGEMODE) == 0) return item.first;
+    return CHANGEMODE_ID(-1);
 }
-
-Model_Asset::RATEMODE Model_Asset::ratemode(const Data* r)
+Model_Asset::CHANGEMODE_ID Model_Asset::changemode_id(const Data& r)
 {
-    for (const auto & item : RATEMODE_CHOICES) if (item.second.CmpNoCase(r->VALUECHANGEMODE) == 0) return item.first;
-    return RATEMODE(-1);
-}
-
-Model_Asset::RATEMODE Model_Asset::ratemode(const Data& r)
-{
-    return ratemode(&r);
-}
-
-Model_Asset::STATUS Model_Asset::status(const Data* r)
-{
-    for (const auto & item : STATUS_CHOICES) if (item.second.CmpNoCase(r->ASSETSTATUS) == 0) return item.first;
-    return STATUS(-1);
-}
-
-Model_Asset::STATUS Model_Asset::status(const Data& r)
-{
-    return status(&r);
+    return changemode_id(&r);
 }
 
 Model_Currency::Data* Model_Asset::currency(const Data* /* r */)
@@ -231,14 +249,14 @@ double Model_Asset::valueAtDate(const Data* r, const wxDate date)
                     wxTimeSpan diff_time = date - tranDate;
                     double diff_time_in_days = static_cast<double>(diff_time.GetDays());
 
-                    switch (rate(r))
+                    switch (change_id(r))
                     {
-                    case RATE_NONE:
+                    case CHANGE_ID_NONE:
                         break;
-                    case RATE_APPRECIATE:
+                    case CHANGE_ID_APPRECIATE:
                         amount *= pow(1.0 + (r->VALUECHANGERATE / 36500.0), diff_time_in_days);
                         break;
-                    case RATE_DEPRECIATE:
+                    case CHANGE_ID_DEPRECIATE:
                         amount *= pow(1.0 - (r->VALUECHANGERATE / 36500.0), diff_time_in_days);
                         break;
                     default:
@@ -254,14 +272,14 @@ double Model_Asset::valueAtDate(const Data* r, const wxDate date)
             wxTimeSpan diff_time = date - STARTDATE(r);
             double diff_time_in_days = static_cast<double>(diff_time.GetDays());
 
-            switch (rate(r))
+            switch (change_id(r))
             {
-            case RATE_NONE:
+            case CHANGE_ID_NONE:
                 break;
-            case RATE_APPRECIATE:
+            case CHANGE_ID_APPRECIATE:
                 balance *= pow(1.0 + (r->VALUECHANGERATE / 36500.0), diff_time_in_days);
                 break;
-            case RATE_DEPRECIATE:
+            case CHANGE_ID_DEPRECIATE:
                 balance *= pow(1.0 - (r->VALUECHANGERATE / 36500.0), diff_time_in_days);
                 break;
             default:

--- a/src/model/Model_Asset.h
+++ b/src/model/Model_Asset.h
@@ -27,23 +27,44 @@
 class Model_Asset : public Model<DB_Table_ASSETS_V1>
 {
 public:
-    enum RATE { RATE_NONE = 0, RATE_APPRECIATE, RATE_DEPRECIATE };
+    enum TYPE_ID
+    {
+        TYPE_ID_PROPERTY = 0,
+        TYPE_ID_AUTO,
+        TYPE_ID_HOUSE,
+        TYPE_ID_ART,
+        TYPE_ID_JEWELLERY,
+        TYPE_ID_CASH,
+        TYPE_ID_OTHER
+    };
+    enum STATUS_ID {
+        STATUS_ID_CLOSED = 0,
+        STATUS_ID_OPEN
+    };
+    enum CHANGE_ID
+    {
+        CHANGE_ID_NONE = 0,
+        CHANGE_ID_APPRECIATE,
+        CHANGE_ID_DEPRECIATE
+    };
+    enum CHANGEMODE_ID {
+        CHANGEMODE_ID_PERCENTAGE = 0,
+        CHANGEMODE_ID_LINEAR
+    };
+    static wxArrayString TYPE_STR;
+    static wxArrayString STATUS_STR;
+    static wxArrayString CHANGE_STR;
+    static wxArrayString CHANGEMODE_STR;
 
-    enum RATEMODE { PERCENTAGE = 0, LINEAR };
-    static const wxString PERCENTAGE_STR;
-    static const wxString LINEAR_STR;
-
-    enum TYPE { TYPE_PROPERTY = 0, TYPE_AUTO, TYPE_HOUSE, TYPE_ART, TYPE_JEWELLERY, TYPE_CASH, TYPE_OTHER };
-
-    enum STATUS { STATUS_CLOSED = 0, STATUS_OPEN };
-    static const wxString OPEN_STR;
-    static const wxString CLOSED_STR;
-
-public:
-    static const std::vector<std::pair<RATE, wxString> > RATE_CHOICES;
-    static const std::vector<std::pair<RATEMODE, wxString> > RATEMODE_CHOICES;
-    static const std::vector<std::pair<TYPE, wxString> > TYPE_CHOICES;
-    static const std::vector<std::pair<STATUS, wxString> > STATUS_CHOICES;
+private:
+    static const std::vector<std::pair<TYPE_ID, wxString> > TYPE_CHOICES;
+    static const std::vector<std::pair<STATUS_ID, wxString> > STATUS_CHOICES;
+    static const std::vector<std::pair<CHANGE_ID, wxString> > CHANGE_CHOICES;
+    static const std::vector<std::pair<CHANGEMODE_ID, wxString> > CHANGEMODE_CHOICES;
+    static wxArrayString type_str_all();
+    static wxArrayString status_str_all();
+    static wxArrayString change_str_all();
+    static wxArrayString changemode_str_all();
 
 public:
     Model_Asset();
@@ -65,27 +86,23 @@ public:
     static Model_Asset& instance();
 
 public:
-    static DB_Table_ASSETS_V1::ASSETTYPE ASSETTYPE(TYPE type, OP op = EQUAL);
+    static DB_Table_ASSETS_V1::ASSETTYPE ASSETTYPE(TYPE_ID type, OP op = EQUAL);
     static DB_Table_ASSETS_V1::STARTDATE STARTDATE(const wxDate& date, OP op = EQUAL);
     
 public:
     static wxString get_asset_name(int asset_id);
-    static wxArrayString all_rate();
-    static wxArrayString all_ratemode();
-    static wxArrayString all_type();
-    static wxArrayString all_status();
     double balance();
     static wxDate STARTDATE(const Data* r);
     static wxDate STARTDATE(const Data& r);
 
-    static TYPE type(const Data* r);
-    static TYPE type(const Data& r);
-    static RATE rate(const Data* r);
-    static RATE rate(const Data& r);
-    static RATEMODE ratemode(const Data* r);
-    static RATEMODE ratemode(const Data& r);
-    static STATUS status(const Data* r);
-    static STATUS status(const Data& r);
+    static TYPE_ID type_id(const Data* r);
+    static TYPE_ID type_id(const Data& r);
+    static STATUS_ID status_id(const Data* r);
+    static STATUS_ID status_id(const Data& r);
+    static CHANGE_ID change_id(const Data* r);
+    static CHANGE_ID change_id(const Data& r);
+    static CHANGEMODE_ID changemode_id(const Data* r);
+    static CHANGEMODE_ID changemode_id(const Data& r);
 
     /** Returns the base currency Data record pointer*/
     static Model_Currency::Data* currency(const Data* /* r */);


### PR DESCRIPTION
This PR is a continuation of #6848.

## Changes in `Model_Asset`

- Rename enum `TYPE` -> `TYPE_ID`, `STATUS` -> `STATUS_ID`, `RATE` -> `CHANGE_ID`, `RATEMODE` -> `CHANGEMODE_ID`.
- Add prefix into enum cases: `TYPE_ID_`, `STATUS_ID_`, `CHANGE_ID_`, `CHANGEMODE_ID_`.
- Rename `RATE_CHOICES` -> `CHANGE_CHOICES`, `RATEMODE_CHOICES` -> `CHANGEMODE_CHOICES`
- Rename `all_type()` -> `type_str_all()`, `all_status()` -> `status_str_all()`, all_rate()` -> `change_str_all()`, all_ratemode()` -> `changemode_str_all()`
- Rename `type()` -> `type_id()`, `status()` -> `status_id()`, `rate()` -> `change_id`, `ratemode()` -> `changemode_id`

No static wxString with prefix `TYPE_STR_`, `STATUS_STR_`, `CHANGE_STR_`, `CHANGEMODE_STR_` are created for `Model_Asset`, because such strings are used in two places only. If needed, they can be created in the future, similar to #6848.
